### PR TITLE
Fix a uses_dynamic_as_bottom error by typing futureToPromise

### DIFF
--- a/lib/src/js_adapter.dart
+++ b/lib/src/js_adapter.dart
@@ -36,10 +36,10 @@ Future<T> promiseToFuture<J, T>(Promise<J> promise,
   return completer.future;
 }
 
-Promise futureToPromise(Future future, [dynamic wrapValue(dynamic value)]) {
-  return new Promise(
+Promise<J> futureToPromise<T, J>(Future<T> future, [J wrapValue(T value)]) {
+  return new Promise<J>(
     allowInterop(
-      (void resolveFn(value), void rejectFn(error)) {
+      (void resolveFn(J value), void rejectFn(error)) {
         future.then((value) {
           dynamic wrapped;
           if (wrapValue != null) {

--- a/lib/src/service_worker_api.dart
+++ b/lib/src/service_worker_api.dart
@@ -690,7 +690,6 @@ class FetchEvent implements Event {
 
   void respondWith(Future<Response> response) {
     _callMethod(_delegate, 'respondWith',
-        // ignore: strong_mode_uses_dynamic_as_bottom
         [futureToPromise(response, (Response r) => r._delegate)]);
   }
 


### PR DESCRIPTION
Analyzer results look clean now.