### PR TITLE
Updates version and changelog to publish 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.1
+
+- Fixed a use of `dynamic` as bottom by adding type parameters to
+  `futureToPromise`.
+
 ## 0.2.0
 
 - Updated to work with `dart:html` for `2.0.0-dev.40.0`:
@@ -59,7 +64,7 @@
 
 ## 0.0.8
 
-- ServiceWorkerClient.postMessage() to use List as transfer objects parameter. 
+- ServiceWorkerClient.postMessage() to use List as transfer objects parameter.
 - ServiceWorker.postMessage(): any Transferable object can be set, not only MessagePorts.
 
 ## 0.0.7

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: service_worker
-version: 0.2.0
+version: 0.2.1
 author: Istvan Soos <istvan.soos@gmail.com>
 description: JavaScript bindings for the Service Worker API.
 


### PR DESCRIPTION
This release fixes a use of `dynamic` as bottom for Dart 2.

[Example of the error](https://travis-ci.org/dart-lang/angular/jobs/368384715#L678) this fixes.

If you'll accept this PR would you please publish the release? Thanks!