### PR TITLE
Fix service worker interop, lints and publish as stable

### DIFF
--- a/.github/workflows/run_ci.yml
+++ b/.github/workflows/run_ci.yml
@@ -1,6 +1,7 @@
 name: Run CI
 on:
   push:
+  pull_request:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * 0'  # every sunday at midnight

--- a/.github/workflows/run_ci.yml
+++ b/.github/workflows/run_ci.yml
@@ -1,6 +1,7 @@
 name: Run CI
 on:
   push:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * 0'  # every sunday at midnight
 

--- a/.github/workflows/run_ci.yml
+++ b/.github/workflows/run_ci.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           sdk: ${{ matrix.dart }}
       # Install dev_test binaries
-      - run: pub global activate dev_test
+      - run: dart pub global activate dev_test
       # Run common validation test (analyzer, format, test) on your package (and nested packages)
-      - run: pub global run dev_test:run_ci
+      - run: dart pub global run dev_test:run_ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+- Stable release
+
 ## 0.3.0-nullsafety.1
 
 - Null safety migration ([#27](https://github.com/isoos/service_worker/pull/27) by [alextekartik](https://github.com/alextekartik)).

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -43,7 +43,6 @@ linter:
     - empty_statements
     - hash_and_equals
     - implementation_imports
-    - invariant_booleans
     - iterable_contains_unrelated_type
     - join_return_with_assignment
     - library_names

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -45,7 +45,7 @@ linter:
     - empty_statements
     - hash_and_equals
     - implementation_imports
-    - invariant_booleans
+    # - invariant_booleans
     - iterable_contains_unrelated_type
     - join_return_with_assignment
     - library_names

--- a/lib/src/js_facade/es6_promise.dart
+++ b/lib/src/js_facade/es6_promise.dart
@@ -12,7 +12,8 @@ import 'package:js/js.dart';
 abstract class Thenable<T> {
   external Thenable<U> then<U>(
       [Thenable<U> Function(T value)? onFulfilled,
-      Function? /* Func1<dynamic, U|Thenable<U>>|VoidFunc1<dynamic> */ onRejected]);
+      Function? /* Func1<dynamic, U|Thenable<U>>|VoidFunc1<dynamic> */
+          onRejected]);
 }
 
 @JS()
@@ -40,7 +41,8 @@ class Promise<T> implements Thenable<T> {
   @override
   external Promise<U> then<U>(
       [Thenable<U> Function(T value)? onFulfilled,
-      Function? /* Func1<dynamic, U|Thenable<U>>|VoidFunc1<dynamic> */ onRejected]);
+      Function? /* Func1<dynamic, U|Thenable<U>>|VoidFunc1<dynamic> */
+          onRejected]);
 
   /// Sugar for promise.then(undefined, onRejected)
   // ignore: non_constant_identifier_names

--- a/lib/src/js_facade/isomorphic_fetch.dart
+++ b/lib/src/js_facade/isomorphic_fetch.dart
@@ -131,24 +131,31 @@ abstract class RequestInterface implements BodyInterface {
   external set url(String v);
   external HeadersInterface get headers;
   external set headers(HeadersInterface v);
-  external String /*''|'audio'|'font'|'image'|'script'|'style'|'track'|'video'*/ get type;
+  external String /*''|'audio'|'font'|'image'|'script'|'style'|'track'|'video'*/
+      get type;
   external set type(
       String /*''|'audio'|'font'|'image'|'script'|'style'|'track'|'video'*/ v);
-  external String /*''|'document'|'embed'|'font'|'image'|'manifest'|'media'|'object'|'report'|'script'|'serviceworker'|'sharedworker'|'style'|'worker'|'xslt'*/ get destination;
+  external String /*''|'document'|'embed'|'font'|'image'|'manifest'|'media'|'object'|'report'|'script'|'serviceworker'|'sharedworker'|'style'|'worker'|'xslt'*/
+      get destination;
   external set destination(
-      String /*''|'document'|'embed'|'font'|'image'|'manifest'|'media'|'object'|'report'|'script'|'serviceworker'|'sharedworker'|'style'|'worker'|'xslt'*/ v);
+      String /*''|'document'|'embed'|'font'|'image'|'manifest'|'media'|'object'|'report'|'script'|'serviceworker'|'sharedworker'|'style'|'worker'|'xslt'*/
+          v);
   external String get referrer;
   external set referrer(String v);
-  external String /*''|'no-referrer'|'no-referrer-when-downgrade'|'same-origin'|'origin'|'strict-origin'|'origin-when-cross-origin'|'strict-origin-when-cross-origin'|'unsafe-url'*/ get referrerPolicy;
+  external String /*''|'no-referrer'|'no-referrer-when-downgrade'|'same-origin'|'origin'|'strict-origin'|'origin-when-cross-origin'|'strict-origin-when-cross-origin'|'unsafe-url'*/
+      get referrerPolicy;
   external set referrerPolicy(
-      String /*''|'no-referrer'|'no-referrer-when-downgrade'|'same-origin'|'origin'|'strict-origin'|'origin-when-cross-origin'|'strict-origin-when-cross-origin'|'unsafe-url'*/ v);
+      String /*''|'no-referrer'|'no-referrer-when-downgrade'|'same-origin'|'origin'|'strict-origin'|'origin-when-cross-origin'|'strict-origin-when-cross-origin'|'unsafe-url'*/
+          v);
   external String /*'navigate'|'same-origin'|'no-cors'|'cors'*/ get mode;
   external set mode(String /*'navigate'|'same-origin'|'no-cors'|'cors'*/ v);
   external String /*'omit'|'same-origin'|'include'*/ get credentials;
   external set credentials(String /*'omit'|'same-origin'|'include'*/ v);
-  external String /*'default'|'no-store'|'reload'|'no-cache'|'force-cache'|'only-if-cached'*/ get cache;
+  external String /*'default'|'no-store'|'reload'|'no-cache'|'force-cache'|'only-if-cached'*/
+      get cache;
   external set cache(
-      String /*'default'|'no-store'|'reload'|'no-cache'|'force-cache'|'only-if-cached'*/ v);
+      String /*'default'|'no-store'|'reload'|'no-cache'|'force-cache'|'only-if-cached'*/
+          v);
   external String /*'follow'|'error'|'manual'*/ get redirect;
   external set redirect(String /*'follow'|'error'|'manual'*/ v);
   external String get integrity;
@@ -166,23 +173,28 @@ abstract class RequestInterface implements BodyInterface {
 abstract class RequestInit {
   external String get method;
   external set method(String v);
-  external dynamic /*Headers|List<String>|JSMap of <String,String>*/ get headers;
+  external dynamic /*Headers|List<String>|JSMap of <String,String>*/
+      get headers;
   external set headers(
       dynamic /*Headers|List<String>|JSMap of <String,String>*/ v);
   external dynamic /*Blob|TypedData|ByteBuffer|FormData|String*/ get body;
   external set body(dynamic /*Blob|TypedData|ByteBuffer|FormData|String*/ v);
   external String get referrer;
   external set referrer(String v);
-  external String /*''|'no-referrer'|'no-referrer-when-downgrade'|'same-origin'|'origin'|'strict-origin'|'origin-when-cross-origin'|'strict-origin-when-cross-origin'|'unsafe-url'*/ get referrerPolicy;
+  external String /*''|'no-referrer'|'no-referrer-when-downgrade'|'same-origin'|'origin'|'strict-origin'|'origin-when-cross-origin'|'strict-origin-when-cross-origin'|'unsafe-url'*/
+      get referrerPolicy;
   external set referrerPolicy(
-      String /*''|'no-referrer'|'no-referrer-when-downgrade'|'same-origin'|'origin'|'strict-origin'|'origin-when-cross-origin'|'strict-origin-when-cross-origin'|'unsafe-url'*/ v);
+      String /*''|'no-referrer'|'no-referrer-when-downgrade'|'same-origin'|'origin'|'strict-origin'|'origin-when-cross-origin'|'strict-origin-when-cross-origin'|'unsafe-url'*/
+          v);
   external String /*'navigate'|'same-origin'|'no-cors'|'cors'*/ get mode;
   external set mode(String /*'navigate'|'same-origin'|'no-cors'|'cors'*/ v);
   external String /*'omit'|'same-origin'|'include'*/ get credentials;
   external set credentials(String /*'omit'|'same-origin'|'include'*/ v);
-  external String /*'default'|'no-store'|'reload'|'no-cache'|'force-cache'|'only-if-cached'*/ get cache;
+  external String /*'default'|'no-store'|'reload'|'no-cache'|'force-cache'|'only-if-cached'*/
+      get cache;
   external set cache(
-      String /*'default'|'no-store'|'reload'|'no-cache'|'force-cache'|'only-if-cached'*/ v);
+      String /*'default'|'no-store'|'reload'|'no-cache'|'force-cache'|'only-if-cached'*/
+          v);
   external String /*'follow'|'error'|'manual'*/ get redirect;
   external set redirect(String /*'follow'|'error'|'manual'*/ v);
   external String get integrity;
@@ -194,10 +206,12 @@ abstract class RequestInit {
       dynamic /*Headers|List<String>|JSMap of <String,String>*/ headers,
       dynamic /*Blob|TypedData|ByteBuffer|FormData|String*/ body,
       String? referrer,
-      String? /*''|'no-referrer'|'no-referrer-when-downgrade'|'same-origin'|'origin'|'strict-origin'|'origin-when-cross-origin'|'strict-origin-when-cross-origin'|'unsafe-url'*/ referrerPolicy,
+      String? /*''|'no-referrer'|'no-referrer-when-downgrade'|'same-origin'|'origin'|'strict-origin'|'origin-when-cross-origin'|'strict-origin-when-cross-origin'|'unsafe-url'*/
+          referrerPolicy,
       String? /*'navigate'|'same-origin'|'no-cors'|'cors'*/ mode,
       String? /*'omit'|'same-origin'|'include'*/ credentials,
-      String? /*'default'|'no-store'|'reload'|'no-cache'|'force-cache'|'only-if-cached'*/ cache,
+      String? /*'default'|'no-store'|'reload'|'no-cache'|'force-cache'|'only-if-cached'*/
+          cache,
       String? /*'follow'|'error'|'manual'*/ redirect,
       String? integrity,
       dynamic window});
@@ -221,24 +235,29 @@ class Request extends Body implements RequestInterface {
   @override
   external set headers(HeadersInterface v);
   @override
-  external String /*''|'audio'|'font'|'image'|'script'|'style'|'track'|'video'*/ get type;
+  external String /*''|'audio'|'font'|'image'|'script'|'style'|'track'|'video'*/
+      get type;
   @override
   external set type(
       String /*''|'audio'|'font'|'image'|'script'|'style'|'track'|'video'*/ v);
   @override
-  external String /*''|'document'|'embed'|'font'|'image'|'manifest'|'media'|'object'|'report'|'script'|'serviceworker'|'sharedworker'|'style'|'worker'|'xslt'*/ get destination;
+  external String /*''|'document'|'embed'|'font'|'image'|'manifest'|'media'|'object'|'report'|'script'|'serviceworker'|'sharedworker'|'style'|'worker'|'xslt'*/
+      get destination;
   @override
   external set destination(
-      String /*''|'document'|'embed'|'font'|'image'|'manifest'|'media'|'object'|'report'|'script'|'serviceworker'|'sharedworker'|'style'|'worker'|'xslt'*/ v);
+      String /*''|'document'|'embed'|'font'|'image'|'manifest'|'media'|'object'|'report'|'script'|'serviceworker'|'sharedworker'|'style'|'worker'|'xslt'*/
+          v);
   @override
   external String get referrer;
   @override
   external set referrer(String v);
   @override
-  external String /*''|'no-referrer'|'no-referrer-when-downgrade'|'same-origin'|'origin'|'strict-origin'|'origin-when-cross-origin'|'strict-origin-when-cross-origin'|'unsafe-url'*/ get referrerPolicy;
+  external String /*''|'no-referrer'|'no-referrer-when-downgrade'|'same-origin'|'origin'|'strict-origin'|'origin-when-cross-origin'|'strict-origin-when-cross-origin'|'unsafe-url'*/
+      get referrerPolicy;
   @override
   external set referrerPolicy(
-      String /*''|'no-referrer'|'no-referrer-when-downgrade'|'same-origin'|'origin'|'strict-origin'|'origin-when-cross-origin'|'strict-origin-when-cross-origin'|'unsafe-url'*/ v);
+      String /*''|'no-referrer'|'no-referrer-when-downgrade'|'same-origin'|'origin'|'strict-origin'|'origin-when-cross-origin'|'strict-origin-when-cross-origin'|'unsafe-url'*/
+          v);
   @override
   external String /*'navigate'|'same-origin'|'no-cors'|'cors'*/ get mode;
   @override
@@ -248,10 +267,12 @@ class Request extends Body implements RequestInterface {
   @override
   external set credentials(String /*'omit'|'same-origin'|'include'*/ v);
   @override
-  external String /*'default'|'no-store'|'reload'|'no-cache'|'force-cache'|'only-if-cached'*/ get cache;
+  external String /*'default'|'no-store'|'reload'|'no-cache'|'force-cache'|'only-if-cached'*/
+      get cache;
   @override
   external set cache(
-      String /*'default'|'no-store'|'reload'|'no-cache'|'force-cache'|'only-if-cached'*/ v);
+      String /*'default'|'no-store'|'reload'|'no-cache'|'force-cache'|'only-if-cached'*/
+          v);
   @override
   external String /*'follow'|'error'|'manual'*/ get redirect;
   @override
@@ -267,7 +288,8 @@ class Request extends Body implements RequestInterface {
 @anonymous
 @JS()
 abstract class ResponseInterface implements BodyInterface {
-  external String /*'basic'|'cors'|'default'|'error'|'opaque'|'opaqueredirect'*/ get type;
+  external String /*'basic'|'cors'|'default'|'error'|'opaque'|'opaqueredirect'*/
+      get type;
   external set type(
       String /*'basic'|'cors'|'default'|'error'|'opaque'|'opaqueredirect'*/ v);
   external String get url;
@@ -300,7 +322,8 @@ abstract class ResponseInit {
   external set status(num v);
   external String get statusText;
   external set statusText(String v);
-  external dynamic /*Headers|List<String>|JSMap of <String,String>*/ get headers;
+  external dynamic /*Headers|List<String>|JSMap of <String,String>*/
+      get headers;
   external set headers(
       dynamic /*Headers|List<String>|JSMap of <String,String>*/ v);
   external factory ResponseInit(
@@ -317,7 +340,8 @@ class Response extends Body implements ResponseInterface {
   external static ResponseInterface redirect(String url, [num? status]);
   external static ResponseInterface error();
   @override
-  external String /*'basic'|'cors'|'default'|'error'|'opaque'|'opaqueredirect'*/ get type;
+  external String /*'basic'|'cors'|'default'|'error'|'opaque'|'opaqueredirect'*/
+      get type;
   @override
   external set type(
       String /*'basic'|'cors'|'default'|'error'|'opaque'|'opaqueredirect'*/ v);

--- a/lib/src/js_facade/isomorphic_fetch.dart
+++ b/lib/src/js_facade/isomorphic_fetch.dart
@@ -51,13 +51,21 @@ import 'promise.dart';
     'unsafe-url';*/
 @anonymous
 @JS()
-abstract class HeadersInterface {
+@staticInterop
+abstract class HeadersInterface {}
+
+extension HeadersInterfaceExt on HeadersInterface {
   external void append(String name, String value);
+
   external void delete(String name);
+
   // ignore: non_constant_identifier_names
   external String /*String|Null*/ JS$get(String name);
+
   external List<String> getAll(String name);
+
   external bool has(String name);
+
   // ignore: non_constant_identifier_names
   external void JS$set(String name, String value);
 
@@ -69,97 +77,102 @@ abstract class HeadersInterface {
 
 /*type HeadersInit = Headers | string[] | { [index: string]: string };*/
 @JS()
+@staticInterop
 class Headers implements HeadersInterface {
   external factory Headers(
       [dynamic /*Headers|List<String>|JSMap of <String,String>*/ init]);
-  @override
-  external void append(String name, String value);
-  @override
-  external void delete(String name);
-  @override
-  // ignore: non_constant_identifier_names
-  external String /*String|Null*/ JS$get(String name);
-  @override
-  external List<String> getAll(String name);
-  @override
-  external bool has(String name);
-  @override
-  // ignore: non_constant_identifier_names
-  external void JS$set(String name, String value);
-  @override
-  external void forEach(
-      void Function(String value, num index, HeadersInterface headers) callback,
-      [dynamic thisArg]);
 }
 
 @anonymous
 @JS()
-abstract class BodyInterface {
+@staticInterop
+abstract class BodyInterface {}
+
+extension BodyInterfaceExt on BodyInterface {
   external bool get bodyUsed;
+
   external set bodyUsed(bool v);
+
   external Promise<ByteBuffer> arrayBuffer();
+
   external Promise<Blob> blob();
+
   external Promise<FormData> formData();
+
   external Promise<T> json<T>();
+
   external Promise<String> text();
 }
 
 @JS()
-class Body implements BodyInterface {
-  @override
-  external bool get bodyUsed;
-  @override
-  external set bodyUsed(bool v);
-  @override
-  external Promise<ByteBuffer> arrayBuffer();
-  @override
-  external Promise<Blob> blob();
-  @override
-  external Promise<FormData> formData();
-  @override
-  external Promise<T> json<T>();
-  @override
-  external Promise<String> text();
-}
+@staticInterop
+class Body implements BodyInterface {}
 
 @anonymous
 @JS()
-abstract class RequestInterface implements BodyInterface {
+@staticInterop
+abstract class RequestInterface implements BodyInterface {}
+
+extension RequestInterfaceExt on BodyInterface {
   external String get method;
+
   external set method(String v);
+
   external String get url;
+
   external set url(String v);
+
   external HeadersInterface get headers;
+
   external set headers(HeadersInterface v);
+
   external String /*''|'audio'|'font'|'image'|'script'|'style'|'track'|'video'*/
       get type;
+
   external set type(
       String /*''|'audio'|'font'|'image'|'script'|'style'|'track'|'video'*/ v);
+
   external String /*''|'document'|'embed'|'font'|'image'|'manifest'|'media'|'object'|'report'|'script'|'serviceworker'|'sharedworker'|'style'|'worker'|'xslt'*/
       get destination;
+
   external set destination(
       String /*''|'document'|'embed'|'font'|'image'|'manifest'|'media'|'object'|'report'|'script'|'serviceworker'|'sharedworker'|'style'|'worker'|'xslt'*/
           v);
+
   external String get referrer;
+
   external set referrer(String v);
+
   external String /*''|'no-referrer'|'no-referrer-when-downgrade'|'same-origin'|'origin'|'strict-origin'|'origin-when-cross-origin'|'strict-origin-when-cross-origin'|'unsafe-url'*/
       get referrerPolicy;
+
   external set referrerPolicy(
       String /*''|'no-referrer'|'no-referrer-when-downgrade'|'same-origin'|'origin'|'strict-origin'|'origin-when-cross-origin'|'strict-origin-when-cross-origin'|'unsafe-url'*/
           v);
+
   external String /*'navigate'|'same-origin'|'no-cors'|'cors'*/ get mode;
+
   external set mode(String /*'navigate'|'same-origin'|'no-cors'|'cors'*/ v);
+
   external String /*'omit'|'same-origin'|'include'*/ get credentials;
+
   external set credentials(String /*'omit'|'same-origin'|'include'*/ v);
+
   external String /*'default'|'no-store'|'reload'|'no-cache'|'force-cache'|'only-if-cached'*/
       get cache;
+
   external set cache(
       String /*'default'|'no-store'|'reload'|'no-cache'|'force-cache'|'only-if-cached'*/
           v);
+
   external String /*'follow'|'error'|'manual'*/ get redirect;
+
   external set redirect(String /*'follow'|'error'|'manual'*/ v);
+
   external String get integrity;
+
   external set integrity(String v);
+
   external RequestInterface clone();
 }
 
@@ -172,35 +185,57 @@ abstract class RequestInterface implements BodyInterface {
 @JS()
 abstract class RequestInit {
   external String get method;
+
   external set method(String v);
+
   external dynamic /*Headers|List<String>|JSMap of <String,String>*/
       get headers;
+
   external set headers(
       dynamic /*Headers|List<String>|JSMap of <String,String>*/ v);
+
   external dynamic /*Blob|TypedData|ByteBuffer|FormData|String*/ get body;
+
   external set body(dynamic /*Blob|TypedData|ByteBuffer|FormData|String*/ v);
+
   external String get referrer;
+
   external set referrer(String v);
+
   external String /*''|'no-referrer'|'no-referrer-when-downgrade'|'same-origin'|'origin'|'strict-origin'|'origin-when-cross-origin'|'strict-origin-when-cross-origin'|'unsafe-url'*/
       get referrerPolicy;
+
   external set referrerPolicy(
       String /*''|'no-referrer'|'no-referrer-when-downgrade'|'same-origin'|'origin'|'strict-origin'|'origin-when-cross-origin'|'strict-origin-when-cross-origin'|'unsafe-url'*/
           v);
+
   external String /*'navigate'|'same-origin'|'no-cors'|'cors'*/ get mode;
+
   external set mode(String /*'navigate'|'same-origin'|'no-cors'|'cors'*/ v);
+
   external String /*'omit'|'same-origin'|'include'*/ get credentials;
+
   external set credentials(String /*'omit'|'same-origin'|'include'*/ v);
+
   external String /*'default'|'no-store'|'reload'|'no-cache'|'force-cache'|'only-if-cached'*/
       get cache;
+
   external set cache(
       String /*'default'|'no-store'|'reload'|'no-cache'|'force-cache'|'only-if-cached'*/
           v);
+
   external String /*'follow'|'error'|'manual'*/ get redirect;
+
   external set redirect(String /*'follow'|'error'|'manual'*/ v);
+
   external String get integrity;
+
   external set integrity(String v);
+
   external dynamic get window;
+
   external set window(dynamic v);
+
   external factory RequestInit(
       {String? method,
       dynamic /*Headers|List<String>|JSMap of <String,String>*/ headers,
@@ -219,98 +254,58 @@ abstract class RequestInit {
 
 /*type RequestInfo = RequestInterface | string;*/
 @JS()
+@staticInterop
 class Request extends Body implements RequestInterface {
   external factory Request(dynamic /*RequestInterface|String*/ input,
       [RequestInit? init]);
-  @override
-  external String get method;
-  @override
-  external set method(String v);
-  @override
-  external String get url;
-  @override
-  external set url(String v);
-  @override
-  external HeadersInterface get headers;
-  @override
-  external set headers(HeadersInterface v);
-  @override
-  external String /*''|'audio'|'font'|'image'|'script'|'style'|'track'|'video'*/
-      get type;
-  @override
-  external set type(
-      String /*''|'audio'|'font'|'image'|'script'|'style'|'track'|'video'*/ v);
-  @override
-  external String /*''|'document'|'embed'|'font'|'image'|'manifest'|'media'|'object'|'report'|'script'|'serviceworker'|'sharedworker'|'style'|'worker'|'xslt'*/
-      get destination;
-  @override
-  external set destination(
-      String /*''|'document'|'embed'|'font'|'image'|'manifest'|'media'|'object'|'report'|'script'|'serviceworker'|'sharedworker'|'style'|'worker'|'xslt'*/
-          v);
-  @override
-  external String get referrer;
-  @override
-  external set referrer(String v);
-  @override
-  external String /*''|'no-referrer'|'no-referrer-when-downgrade'|'same-origin'|'origin'|'strict-origin'|'origin-when-cross-origin'|'strict-origin-when-cross-origin'|'unsafe-url'*/
-      get referrerPolicy;
-  @override
-  external set referrerPolicy(
-      String /*''|'no-referrer'|'no-referrer-when-downgrade'|'same-origin'|'origin'|'strict-origin'|'origin-when-cross-origin'|'strict-origin-when-cross-origin'|'unsafe-url'*/
-          v);
-  @override
-  external String /*'navigate'|'same-origin'|'no-cors'|'cors'*/ get mode;
-  @override
-  external set mode(String /*'navigate'|'same-origin'|'no-cors'|'cors'*/ v);
-  @override
-  external String /*'omit'|'same-origin'|'include'*/ get credentials;
-  @override
-  external set credentials(String /*'omit'|'same-origin'|'include'*/ v);
-  @override
-  external String /*'default'|'no-store'|'reload'|'no-cache'|'force-cache'|'only-if-cached'*/
-      get cache;
-  @override
-  external set cache(
-      String /*'default'|'no-store'|'reload'|'no-cache'|'force-cache'|'only-if-cached'*/
-          v);
-  @override
-  external String /*'follow'|'error'|'manual'*/ get redirect;
-  @override
-  external set redirect(String /*'follow'|'error'|'manual'*/ v);
-  @override
-  external String get integrity;
-  @override
-  external set integrity(String v);
-  @override
-  external RequestInterface clone();
 }
 
 @anonymous
 @JS()
-abstract class ResponseInterface implements BodyInterface {
+@staticInterop
+abstract class ResponseInterface implements BodyInterface {}
+
+extension ResponseInterfaceExt on ResponseInterface {
   external String /*'basic'|'cors'|'default'|'error'|'opaque'|'opaqueredirect'*/
       get type;
+
   external set type(
       String /*'basic'|'cors'|'default'|'error'|'opaque'|'opaqueredirect'*/ v);
+
   external String get url;
+
   external set url(String v);
+
   external bool get redirected;
+
   external set redirected(bool v);
+
   external num get status;
+
   external set status(num v);
+
   external String get statusText;
+
   external set statusText(String v);
+
   external bool get ok;
+
   external set ok(bool v);
+
   external HeadersInterface get headers;
+
   external set headers(HeadersInterface v);
 
   /// size: number;
   /// timeout: number;
   external dynamic get body;
+
   external set body(dynamic v);
+
   external Promise<HeadersInterface> get trailer;
+
   external set trailer(Promise<HeadersInterface> v);
+
   external ResponseInterface clone();
 }
 
@@ -319,13 +314,19 @@ abstract class ResponseInterface implements BodyInterface {
 @JS()
 abstract class ResponseInit {
   external num get status;
+
   external set status(num v);
+
   external String get statusText;
+
   external set statusText(String v);
+
   external dynamic /*Headers|List<String>|JSMap of <String,String>*/
       get headers;
+
   external set headers(
       dynamic /*Headers|List<String>|JSMap of <String,String>*/ v);
+
   external factory ResponseInit(
       {num? status,
       String? statusText,
@@ -333,57 +334,21 @@ abstract class ResponseInit {
 }
 
 @JS()
+@staticInterop
 class Response extends Body implements ResponseInterface {
   external factory Response(
       [dynamic /*Blob|TypedData|ByteBuffer|FormData|String*/ body,
       ResponseInit? init]);
+
   external static ResponseInterface redirect(String url, [num? status]);
+
   external static ResponseInterface error();
-  @override
-  external String /*'basic'|'cors'|'default'|'error'|'opaque'|'opaqueredirect'*/
-      get type;
-  @override
-  external set type(
-      String /*'basic'|'cors'|'default'|'error'|'opaque'|'opaqueredirect'*/ v);
-  @override
-  external String get url;
-  @override
-  external set url(String v);
-  @override
-  external bool get redirected;
-  @override
-  external set redirected(bool v);
-  @override
-  external num get status;
-  @override
-  external set status(num v);
-  @override
-  external String get statusText;
-  @override
-  external set statusText(String v);
-  @override
-  external bool get ok;
-  @override
-  external set ok(bool v);
-  @override
-  external HeadersInterface get headers;
-  @override
-  external set headers(HeadersInterface v);
-  @override
-  external dynamic get body;
-  @override
-  external set body(dynamic v);
-  @override
-  external Promise<HeadersInterface> get trailer;
-  @override
-  external set trailer(Promise<HeadersInterface> v);
-  @override
-  external ResponseInterface clone();
 }
 
 /* Skipping class Window*/
 @JS()
 external dynamic get fetch;
+
 @JS()
 external set fetch(dynamic v);
 // Module isomorphic-fetch

--- a/lib/src/service_worker_api.dart
+++ b/lib/src/service_worker_api.dart
@@ -89,19 +89,19 @@ class ServiceWorkerGlobalScope {
   /// An event handler fired whenever an activate event occurs — when a
   /// ServiceWorkerRegistration acquires a new ServiceWorkerRegistration.active
   /// worker.
-  Stream<ExtendableEvent> get onActivate => _onActivate ??= callbackToStream(
-      _delegate, 'onactivate', (Object j) => ExtendableEvent._(j));
+  Stream<ExtendableEvent> get onActivate => _onActivate ??=
+      callbackToStream(_delegate, 'onactivate', ExtendableEvent._);
 
   /// An event handler fired whenever a fetch event occurs — when a fetch()
   /// is called.
-  Stream<FetchEvent> get onFetch => _onFetch ??=
-      callbackToStream(_delegate, 'onfetch', (Object j) => FetchEvent._(j));
+  Stream<FetchEvent> get onFetch =>
+      _onFetch ??= callbackToStream(_delegate, 'onfetch', FetchEvent._);
 
   /// An event handler fired whenever an install event occurs — when a
   /// ServiceWorkerRegistration acquires a new
   /// ServiceWorkerRegistration.installing worker.
-  Stream<InstallEvent> get onInstall => _onInstall ??=
-      callbackToStream(_delegate, 'oninstall', (Object j) => InstallEvent._(j));
+  Stream<InstallEvent> get onInstall =>
+      _onInstall ??= callbackToStream(_delegate, 'oninstall', InstallEvent._);
 
   /// An event handler fired whenever a message event occurs — when incoming
   /// messages are received. Controlled pages can use the
@@ -113,28 +113,25 @@ class ServiceWorkerGlobalScope {
   /// since we are merging the interface into `Window`, we should
   /// make sure it's compatible with `window.onmessage`
   /// onmessage: (messageevent: ExtendableMessageEvent) => void;
-  Stream<ExtendableMessageEvent> get onMessage =>
-      _onMessage ??= callbackToStream(
-          _delegate, 'onmessage', (Object j) => ExtendableMessageEvent._(j));
+  Stream<ExtendableMessageEvent> get onMessage => _onMessage ??=
+      callbackToStream(_delegate, 'onmessage', ExtendableMessageEvent._);
 
   /// An event handler fired whenever a notificationclick event occurs — when
   /// a user clicks on a displayed notification.
-  Stream<NotificationEvent> get onNotificationClick =>
-      _onNotificationClick ??= callbackToStream(_delegate,
-          'onnotificationclick', (Object j) => NotificationEvent._(j));
+  Stream<NotificationEvent> get onNotificationClick => _onNotificationClick ??=
+      callbackToStream(_delegate, 'onnotificationclick', NotificationEvent._);
 
   /// An event handler fired whenever a push event occurs — when a server
   /// push notification is received.
-  Stream<PushEvent> get onPush =>
-      _onPush ??= callbackToStream<Object, PushEvent>(
-          _delegate, 'onpush', (Object j) => PushEvent._(j));
+  Stream<PushEvent> get onPush => _onPush ??=
+      callbackToStream<Object, PushEvent>(_delegate, 'onpush', PushEvent._);
 
   /// An event handler fired whenever a pushsubscriptionchange event occurs —
   /// when a push subscription has been invalidated, or is about to be
   /// invalidated (e.g. when a push service sets an expiration time).
   Stream<PushEvent> get onPushSubscriptionChange =>
-      _onPushSubscriptionChange ??= callbackToStream(
-          _delegate, 'onpushsubscriptionchange', (Object j) => PushEvent._(j));
+      _onPushSubscriptionChange ??=
+          callbackToStream(_delegate, 'onpushsubscriptionchange', PushEvent._);
 
   /// Allows the current service worker registration to progress from waiting
   /// to active state while service worker clients are using it.
@@ -155,7 +152,7 @@ class ServiceWorkerGlobalScope {
       args.add(requestInit);
     }
     return promiseToFuture<Object, Response>(
-        _callMethod(_delegate, 'fetch', args), (Object j) => Response._(j));
+        _callMethod(_delegate, 'fetch', args), Response._);
   }
 
   /// Returns the indexedDB in the current scope.
@@ -197,8 +194,7 @@ class ServiceWorkerContainer {
   /// ServiceWorkerRegistration with an ServiceWorkerRegistration.active worker.
   Future<ServiceWorkerRegistration> get ready =>
       promiseToFuture<Object, ServiceWorkerRegistration>(
-          _getProperty(_delegate, 'ready'),
-          (Object j) => ServiceWorkerRegistration._(j));
+          _getProperty(_delegate, 'ready'), ServiceWorkerRegistration._);
 
   /// An event handler fired whenever a controllerchange event occurs — when
   /// the document's associated ServiceWorkerRegistration acquires a new
@@ -227,7 +223,7 @@ class ServiceWorkerContainer {
           [ServiceWorkerRegisterOptions? options]) =>
       promiseToFuture<Object, ServiceWorkerRegistration>(
           _callMethod(_delegate, 'register', [scriptURL, options]),
-          (Object j) => ServiceWorkerRegistration._(j));
+          ServiceWorkerRegistration._);
 
   /// Gets a ServiceWorkerRegistration object whose scope URL matches the
   /// provided document URL.  If the method can't return a
@@ -237,7 +233,7 @@ class ServiceWorkerContainer {
   Future<ServiceWorkerRegistration> getRegistration([String? scope]) =>
       promiseToFuture<Object, ServiceWorkerRegistration>(
           _callMethod(_delegate, 'getRegistration', [scope]),
-          (Object j) => ServiceWorkerRegistration._(j));
+          ServiceWorkerRegistration._);
 
   /// Returns all ServiceWorkerRegistrations associated with a
   /// ServiceWorkerContainer in an array.  If the method can't return
@@ -285,7 +281,7 @@ class CacheStorage {
   /// Returns a Promise that resolves to the Cache object matching
   /// the cacheName.
   Future<Cache> open(String cacheName) => promiseToFuture<Object, Cache>(
-      _callMethod(_delegate, 'open', [cacheName]), (Object j) => Cache._(j));
+      _callMethod(_delegate, 'open', [cacheName]), Cache._);
 
   /// Finds the Cache object matching the cacheName, and if found, deletes the
   /// Cache object and returns a Promise that resolves to true. If no
@@ -298,8 +294,7 @@ class CacheStorage {
   /// CacheStorage. Use this method to iterate over a list of all the
   /// Cache objects.
   Future<List<String>> keys() => promiseToFuture<List, List<String>>(
-      _callMethod(_delegate, 'keys', []),
-      (List list) => List<String>.from(list));
+      _callMethod(_delegate, 'keys', []), List<String>.from);
 }
 
 /// Represents the storage for Request / Response object pairs that are cached as
@@ -379,8 +374,7 @@ class ServiceWorkerClients {
   /// Gets a service worker client matching a given id and returns it in a Promise.
   Future<ServiceWorkerClient> operator [](String clientId) =>
       promiseToFuture<Object, ServiceWorkerClient>(
-          _callMethod(_delegate, 'get', [clientId]),
-          (Object j) => ServiceWorkerClient._(j));
+          _callMethod(_delegate, 'get', [clientId]), ServiceWorkerClient._);
 
   /// Gets a list of service worker clients and returns them in a Promise.
   /// Include the options parameter to return all service worker clients whose
@@ -400,8 +394,7 @@ class ServiceWorkerClients {
   /// in the window.
   Future<WindowClient> openWindow(String url) =>
       promiseToFuture<Object, WindowClient>(
-          _callMethod(_delegate, 'openWindow', [url]),
-          (Object j) => WindowClient._(j));
+          _callMethod(_delegate, 'openWindow', [url]), WindowClient._);
 
   /// Allows an active Service Worker to set itself as the active worker for a
   /// client page when the worker and the page are in the same scope.
@@ -502,8 +495,7 @@ class ServiceWorkerRegistration implements EventTarget {
   /// Allows you to update a service worker.
   Future<ServiceWorkerRegistration> update() =>
       promiseToFuture<Object, ServiceWorkerRegistration>(
-          _callMethod(_delegate, 'update', []),
-          (Object j) => ServiceWorkerRegistration._(j));
+          _callMethod(_delegate, 'update', []), ServiceWorkerRegistration._);
 
   /// Unregisters the service worker registration and returns a promise
   /// (see Promise). The service worker will finish any ongoing operations
@@ -536,8 +528,7 @@ class ServiceWorkerRegistration implements EventTarget {
     List args = [title];
     if (options != null) args.add(options);
     return promiseToFuture<Object, NotificationEvent>(
-        _callMethod(_delegate, 'showNotification', args),
-        (Object j) => NotificationEvent._(j));
+        _callMethod(_delegate, 'showNotification', args), NotificationEvent._);
   }
 }
 
@@ -554,15 +545,13 @@ class PushManager {
   /// new push subscription.
   Future<PushSubscription> subscribe([PushSubscriptionOptions? options]) =>
       promiseToFuture<Object, PushSubscription>(
-          _callMethod(_delegate, 'subscribe', [options]),
-          (Object j) => PushSubscription._(j));
+          _callMethod(_delegate, 'subscribe', [options]), PushSubscription._);
 
   /// Returns a promise that resolves to a PushSubscription details of
   /// the retrieved push subscription.
   Future<PushSubscription> getSubscription() =>
       promiseToFuture<Object, PushSubscription>(
-          _callMethod(_delegate, 'getSubscription', []),
-          (Object j) => PushSubscription._(j));
+          _callMethod(_delegate, 'getSubscription', []), PushSubscription._);
 
   /// Returns a promise that resolves to the PushPermissionStatus of the
   /// requesting webapp, which will be one of granted, denied, or default.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,14 @@
 name: service_worker
-version: 0.3.0-nullsafety.1
+version: 0.3.0
 description: JavaScript bindings for the Service Worker API.
 
 homepage: https://github.com/isoos/service_worker
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 
 dependencies:
-  js: ^0.6.1
+  js: '>=0.6.1 <2.0.0'
 
 dev_dependencies:
-  lints: ^1.0.0
+  lints: '>=1.0.0 <3.0.0'


### PR DESCRIPTION
Hi, I'm now using this package to support SQLite on the web (https://github.com/tekartik/sqflite/tree/master/packages_web/sqflite_common_ffi_web) running in a web worker (!). This package is quite convenient for writing webworker in using dart.

I had some compile errors:
```
Error: Non-static JS interop class 'Headers' conflicts with natively supported class 'Headers' in 'dart:html'.
Error: Non-static JS interop class 'Body' conflicts with natively supported class 'Body' in 'dart:html'.
Error: Non-static JS interop class 'Request' conflicts with natively supported class '_Request' in 'dart:html'.
Error: Non-static JS interop class 'Response' conflicts with natively supported class '_Response' in 'dart:html'.
```

that requires an update in your package. There is nothing really to test my changes (besides SQLite which perform http and indexed db operations) are correct. I also updated the min sdk and dependencies (you might see that I allow versioning to even an upper number as it is more convenient to handle conflicts or packages not up to date). It fixed the new lints error and github CI action https://github.com/tekartik-2/service_worker/actions that should now work again.